### PR TITLE
Bugfix filterfile command not found

### DIFF
--- a/privoxy-blocklist.sh
+++ b/privoxy-blocklist.sh
@@ -151,7 +151,7 @@ function main()
 
     # install Privoxy filterfile
     install -o ${PRIVOXY_USER} -g ${PRIVOXY_GROUP} ${VERBOSE} ${filterfile} ${PRIVOXY_DIR}
-    if $(grep $(basename ${filterfile}) ${PRIVOXY_CONF})
+    if [ "$(grep $(basename ${filterfile}) ${PRIVOXY_CONF})" == "" ] 
     then
       debug "\nModifying ${PRIVOXY_CONF} ..." 0
       sed "s/^\(#*\)filterfile user\.filter/filterfile $(basename ${filterfile})\n\1filterfile user.filter/" ${PRIVOXY_CONF} > ${TMPDIR}/config


### PR DESCRIPTION
On my ubuntu 12.04 system the original line caused a filterfile command not found output
