### PR TITLE
Extend tests

### DIFF
--- a/.ci_config/prospector.yaml
+++ b/.ci_config/prospector.yaml
@@ -1,5 +1,8 @@
 ---
 autodetect: false
+doc-warnings: true
+member-warnings: true
+test-warnings: true
 inherits:
   - default
 
@@ -7,3 +10,6 @@ bandit:
   run: true
   options:
     config: .ci_config/bandit.yml
+
+mypy:
+  run: true

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 99

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,6 +31,12 @@ jobs:
           sudo pip install -r ./tests/requirements.txt
           sudo systemctl disable --now privoxy || true
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ runner.debug || vars.ACTIONS_STEP_DEBUG == "true" }}
+        with:
+          limit-access-to-actor: true
+
       - name: run pytest
         env:
           ACTIONS_STEP_DEBUG: ${{ vars.ACTIONS_STEP_DEBUG }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,9 @@ jobs:
           sudo apt-get install python3-pip --yes
           sudo sh helper/install_deps.sh
           pip install -r ./tests/requirements.txt
-          service privoxy stop || true
+          sudo systemctl disable --now privoxy || true
 
       - name: run pytest
-        run: pytest -v -s --color yes tests/
+        run: |
+          sudo pkill -9 privoxy || true
+          pytest -v -s --color yes tests/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,9 +1,6 @@
 ---
 # yamllint disable rule:line-length
 name: "Test Suite"
-env:
-  ACTIONS_STEP_DEBUG: ${{ vars.ACTIONS_STEP_DEBUG }}
-  RUNNER_DEBUG: ${{ runner.debug }}
 
 "on":
   push:
@@ -35,6 +32,9 @@ jobs:
           sudo systemctl disable --now privoxy || true
 
       - name: run pytest
+        env:
+          ACTIONS_STEP_DEBUG: ${{ vars.ACTIONS_STEP_DEBUG }}
+          RUNNER_DEBUG: ${{ runner.debug }}
         run: |
           sudo pkill -9 privoxy || true
           # run pytest as sudo to allow pytestshellutils to stop privoxy

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,12 +31,6 @@ jobs:
           sudo pip install -r ./tests/requirements.txt
           sudo systemctl disable --now privoxy || true
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ runner.debug || vars.ACTIONS_STEP_DEBUG == 'true' }}
-        with:
-          limit-access-to-actor: true
-
       - name: run pytest
         env:
           ACTIONS_STEP_DEBUG: ${{ vars.ACTIONS_STEP_DEBUG }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,4 +38,4 @@ jobs:
         run: |
           sudo pkill -9 privoxy || true
           # run pytest as sudo to allow pytestshellutils to stop privoxy
-          sudo pytest -v -s --color yes tests/
+          sudo --preserve-env=ACTIONS_STEP_DEBUG,RUNNER_DEBUG pytest -v -s --color yes tests/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ runner.debug || vars.ACTIONS_STEP_DEBUG == "true" }}
+        if: ${{ runner.debug || vars.ACTIONS_STEP_DEBUG == 'true' }}
         with:
           limit-access-to-actor: true
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,9 @@
 ---
 # yamllint disable rule:line-length
 name: "Test Suite"
+env:
+  ACTIONS_STEP_DEBUG: ${{ vars.ACTIONS_STEP_DEBUG }}
+  RUNNER_DEBUG: ${{ runner.debug }}
 
 "on":
   push:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,10 +27,12 @@ jobs:
           sudo apt-get update -qq --yes
           sudo apt-get install python3-pip --yes
           sudo sh helper/install_deps.sh
-          pip install -r ./tests/requirements.txt
+          # install via sudo to run pytest as root - see below
+          sudo pip install -r ./tests/requirements.txt
           sudo systemctl disable --now privoxy || true
 
       - name: run pytest
         run: |
           sudo pkill -9 privoxy || true
-          pytest -v -s --color yes tests/
+          # run pytest as sudo to allow pytestshellutils to stop privoxy
+          sudo pytest -v -s --color yes tests/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/.mypy_cache
 **/.pytest_cache
 **/.ropeproject
+**/pytestdebug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 **/__pycache__/**
+**/.mypy_cache
+**/.pytest_cache
+**/.ropeproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,13 +59,29 @@ repos:
           - '--profile'
           - '.ci_config/prospector.yaml'
         additional_dependencies:
-          - ".[with_mypy,with_bandit,with_pylint,with_mccabe,with_pydocstyle]"
+          # cannot use with_ syntax as pre-commit.ci does not support it
+          - bandit
+          - mccabe
+          - mypy
+          - pydocstyle
+          - pylint
           - pytest
           - pytest-shell-utilities
-          - types-requests
           - requests
+          - types-requests
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.27.3
     hooks:
       - id: check-github-workflows
       - id: check-github-actions
+  - repo: local
+    hooks:
+      - id: permission-check
+        name: check permissions using pytest
+        entry: pytest -v -s -k test_permissions tests/test_00_minimal.py
+        language: python
+        pass_filenames: false
+        additional_dependencies:
+          - pytest
+          - pytest-shell-utilities
+          - requests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,13 @@ repos:
           - 'DL3008'
           - '--ignore'
           - 'DL3013'
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args:
+          - '--profile'
+          - 'black'
   - repo: https://github.com/psf/black
     rev: 23.12.1
     hooks:
@@ -52,9 +59,11 @@ repos:
           - '--profile'
           - '.ci_config/prospector.yaml'
         additional_dependencies:
-          - bandit
+          - ".[with_mypy,with_bandit,with_pylint,with_mccabe,with_pydocstyle]"
           - pytest
           - pytest-shell-utilities
+          - types-requests
+          - requests
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.27.3
     hooks:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,70 @@ Due to this behaviour the script must run as root user to be able to modify the 
 
 Either run `privoxy-blocklist.sh` manually with root privileges (e.g., `sudo privoxy-blocklist.sh`) or via root cronjob.
 
+## Feature Support
+
+The following table shows features of AdBlock Plus filters and there status within privoxy-blocklist:
+
+| Feature | Type | Status | Test |
+| ------- | ---- | ------ | ---- |
+| `#$#` | CSS selector - Snippet filter | :question: | :question: |
+| `:-abp-contains()` | extended CSS selector | :question: | :question: |
+| `:-abp-has()` | extended CSS selector | :question: | :question: |
+| `:-abp-properties()` | extended CSS selector | :question: | :question: |
+| `||…` | block domain matching excluding scheme | :question: | :question: |
+| `|…|` | block exact domain matching including scheme | :question: | :question: |
+| `!…` | comments | :white_check_mark: | |
+| `csp=` | filter options | :question: | :question: |
+| `##…[…]` | CSS attribute selector | :question: | :question: |
+| `##` | CSS selector - Element hiding | :white_check_mark: | |
+| `#?#` | CSS selector - Element hiding emulation | :question: | :question: |
+| `#@#` | CSS selector - Element hiding exception | :question: | :question: |
+| `document` | filter options | :question: | :question: |
+| `~domain=` | filter options | :question: | :question: |
+| `domain=` | filter options | :question: | :question: |
+| `~elemhide` | filter options | :question: | :question: |
+| `elemhide` | filter options | :question: | :question: |
+| `@@||…` | exception for blocking rules | :white_check_mark: | |
+| `font` | filter options | :question: | :question: |
+| `genericblock` | filter options | :question: | :question: |
+| `generichide` | filter options | :question: | :question: |
+| `~image` | filter options | :question: | :question: |
+| `image` | filter options | :white_check_mark: | |
+| `match-case` | filter options | :question: | :question: |
+| `media` | filter options | :question: | :question: |
+| `~object` | filter options | :question: | :question: |
+| `object` | filter options | :question: | :question: |
+| `~other` | filter options | :question: | :question: |
+| `other` | filter options | :question: | :question: |
+| `~ping` | filter options | :question: | :question: |
+| `ping` | filter options | :question: | :question: |
+| `popup` | filter options | :question: | :question: |
+| `rewrite=` | filter options | :question: | :question: |
+| `~script` | filter options | :question: | :question: |
+| `script`  | filter options | :question: | :question: |
+| `sitekey=` | filter options | :question: | :question: |
+| `~stylesheet` | filter options | :question: | :question: |
+| `stylesheet` | filter options | :question: | :question: |
+| `~subdocument` | filter options | :question: | :question: |
+| `subdocument` | filter options | :question: | :question: |
+| `~third-party` | filter options | :question: | :question: |
+| `third-party` | filter options | :question: | :question: |
+| `~webrtc` | filter options | :question: | :question: |
+| `webrtc` | filter options | :question: | :question: |
+| `~websocket` | filter options | :question: | :question: |
+| `websocket` | filter options | :question: | :question: |
+| `~xmlhttprequest` | filter options | :question: | :question: |
+| `xmlhttprequest` | filter options | :question: | :question: |
+
+* :question: => status must be checked
+* :white_check_mark: => implemented
+* :construction: => work in progress
+
+Sources:
+
+* [](https://help.adblockplus.org/hc/en-us/articles/360062733293#options)
+* [](https://adblockplus.org/filter-cheatsheet)
+
 ## Development
 
 ### Release

--- a/helper/install_deps.sh
+++ b/helper/install_deps.sh
@@ -26,6 +26,7 @@ if exists apt-get; then
     # prepare HTTPS inspection
     mkdir -p /etc/privoxy/CA/certs /usr/local/share/ca-certificates/privoxy
     openssl req -new -x509 -extensions v3_ca -keyout /etc/privoxy/CA/cakey.pem -out /etc/privoxy/CA/cacert.crt -days 3650 -noenc -batch
+    chown -R privoxy /etc/privoxy/CA
     if ! grep -q '^{+https-inspection}' /etc/privoxy/user.action; then
         cat >> /etc/privoxy/user.action << EOF
 {+https-inspection}

--- a/helper/install_deps.sh
+++ b/helper/install_deps.sh
@@ -11,16 +11,54 @@ exists() {
 
 if exists apk; then
     apk add --no-cache privoxy sed grep bash wget
+    if ! grep -q '^debug' /etc/privoxy/config; then
+        cat >> /etc/privoxy/config << EOF
+# activate debugging of rules & access log
+debug 8704
+EOF
+    fi
     exit 0
 fi
 if exists apt-get; then
     export DEBIAN_FRONTEND=noninteractive
     apt-get update -qq -y
     apt-get install -y privoxy sed grep bash wget
+    # prepare HTTPS inspection
+    mkdir -p /etc/privoxy/CA /usr/local/share/ca-certificates/privoxy
+    openssl req -new -x509 -extensions v3_ca -keyout /etc/privoxy/CA/cakey.pem -out /etc/privoxy/CA/cacert.crt -days 3650 -noenc -batch
+    if ! grep -q '^{+https-inspection}' /etc/privoxy/user.action; then
+        cat >> /etc/privoxy/user.action << EOF
+{+https-inspection}
+.
+EOF
+    fi
+    if ! grep -q '^ca-directory' /etc/privoxy/config; then
+        cat >> /etc/privoxy/config << EOF
+ca-directory /etc/privoxy/CA
+certificate-directory /var/lib/privoxy/certs
+trusted-cas-file /etc/ssl/certs/ca-certificates.crt
+ca-cert-file cacert.crt
+ca-key-file cakey.pem
+# activate debugging of rules & access log
+debug 8704
+EOF
+    fi
+    if [ -e /usr/local/share/ca-certificates/privoxy/privoxy-cacert.crt ]; then
+        rm /usr/local/share/ca-certificates/privoxy/privoxy-cacert.crt /etc/ssl/certs/privoxy-cacert.pem
+    fi
+    ln -s /etc/privoxy/CA/cacert.crt /usr/local/share/ca-certificates/privoxy/privoxy-cacert.crt
+    update-ca-certificates
+    c_rehash
     exit 0
 fi
 if exists pacman; then
     pacman -Sy privoxy sed grep bash wget
+    if ! grep -q '^debug' /etc/privoxy/config; then
+        cat >> /etc/privoxy/config << EOF
+# activate debugging of rules & access log
+debug 8704
+EOF
+    fi
     exit 0
 fi
 echo "no install command found"

--- a/helper/install_deps.sh
+++ b/helper/install_deps.sh
@@ -24,7 +24,7 @@ if exists apt-get; then
     apt-get update -qq -y
     apt-get install -y privoxy sed grep bash wget
     # prepare HTTPS inspection
-    mkdir -p /etc/privoxy/CA /usr/local/share/ca-certificates/privoxy
+    mkdir -p /etc/privoxy/CA/certs /usr/local/share/ca-certificates/privoxy
     openssl req -new -x509 -extensions v3_ca -keyout /etc/privoxy/CA/cakey.pem -out /etc/privoxy/CA/cacert.crt -days 3650 -noenc -batch
     if ! grep -q '^{+https-inspection}' /etc/privoxy/user.action; then
         cat >> /etc/privoxy/user.action << EOF
@@ -35,7 +35,7 @@ EOF
     if ! grep -q '^ca-directory' /etc/privoxy/config; then
         cat >> /etc/privoxy/config << EOF
 ca-directory /etc/privoxy/CA
-certificate-directory /var/lib/privoxy/certs
+certificate-directory /etc/privoxy/CA/certs
 trusted-cas-file /etc/ssl/certs/ca-certificates.crt
 ca-cert-file cacert.crt
 ca-key-file cakey.pem

--- a/helper/install_deps.sh
+++ b/helper/install_deps.sh
@@ -35,7 +35,7 @@ EOF
     if ! grep -q '^ca-directory' /etc/privoxy/config; then
         cat >> /etc/privoxy/config << EOF
 ca-directory /etc/privoxy/CA
-certificate-directory /etc/privoxy/CA/certs
+certificate-directory /var/lib/privoxy/certs
 trusted-cas-file /etc/ssl/certs/ca-certificates.crt
 ca-cert-file cacert.crt
 ca-key-file cakey.pem

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,8 +50,8 @@ def privoxy_blocklist() -> str:
 def start_privoxy(request) -> Generator[bool, None, None]:
     """Test start of privoxy."""
     run = Daemon(
-        script_name="/usr/sbin/privoxy",
-        base_script_args=["--no-daemon"],
+        script_name="/usr/bin/sudo",
+        base_script_args=["/usr/sbin/privoxy", "--no-daemon"],
         cwd="/etc/privoxy",
         start_timeout=10,
         check_ports=[8118],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,18 @@ from pytestshellutils.shell import Daemon
 phase_report_key = StashKey[Dict[str, CollectReport]]()
 
 
+def debug_enabled() -> bool:
+    """Check if debugging is enabled."""
+    # RUNNER_DEBUG = set when "debug logging" activated
+    # ACTIONS_RUNNER_DEBUG = set via repository variable
+    # DEBUG = custom environment variable
+    return (
+        os.environ.get("DEBUG", None) is not None
+        or os.environ.get("RUNNER_DEBUG", None) in [1, "1"]
+        or os.environ.get("ACTIONS_RUNNER_DEBUG", None) in [True, "true"]
+    )
+
+
 # based on
 # https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
 @pytest.hookimpl(wrapper=True, tryfirst=True)
@@ -50,9 +62,8 @@ def privoxy_blocklist() -> str:
 @pytest.fixture(scope="module")
 def start_privoxy(request: pytest.FixtureRequest) -> Generator[bool, None, None]:
     """Test start of privoxy."""
-    if os.environ.get("RUNNER_DEBUG", None) or os.environ.get(
-        "ACTIONS_RUNNER_DEBUG", None
-    ):
+    print("debugging: ", debug_enabled())
+    if debug_enabled():
         for env in ["USER", "UID", "PWD"]:
             print(env, ": ", os.environ.get(env))
         for path in [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,13 @@ def start_privoxy(request: pytest.FixtureRequest) -> Generator[bool, None, None]
             if not path_obj.exists():
                 print(path, " does not exist. ----------------")
                 continue
-            print(path, ":", oct(path_obj.stat().st_mode))
+            print(
+                path,
+                ":",
+                oct(path_obj.stat().st_mode),
+                path_obj.stat().st_uid,
+                path_obj.stat().st_gid,
+            )
     run = Daemon(
         script_name="/usr/sbin/privoxy",
         base_script_args=["--no-daemon", "--user", "root"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,8 @@ def debug_enabled() -> bool:
     # DEBUG = custom environment variable
     return (
         os.environ.get("DEBUG", None) is not None
-        or os.environ.get("RUNNER_DEBUG", None) in [1, "1"]
-        or os.environ.get("ACTIONS_STEP_DEBUG", None) in [True, "true"]
+        or os.environ.get("RUNNER_DEBUG", None) is not None
+        or os.environ.get("ACTIONS_STEP_DEBUG", None) is not None
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,8 +51,8 @@ def privoxy_blocklist() -> str:
 def start_privoxy(request: pytest.FixtureRequest) -> Generator[bool, None, None]:
     """Test start of privoxy."""
     run = Daemon(
-        script_name="/usr/bin/sudo",
-        base_script_args=["/usr/sbin/privoxy", "--no-daemon"],
+        script_name="/usr/sbin/privoxy",
+        base_script_args=["--no-daemon"],
         cwd="/etc/privoxy",
         start_timeout=10,
         check_ports=[8118],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ define generic custom fixtures
 import os
 from pathlib import Path
 import pytest
+import pytestshellutils
 
 
 @pytest.fixture
@@ -20,3 +21,25 @@ def privoxy_blocklist():
         if path.exists() and path.is_file() and os.access(path, os.X_OK):
             return str(path.absolute())
     raise FileNotFoundError("Could not find privoxy-blocklist.sh")
+
+
+@pytest.fixture(scope="module")
+def start_privoxy(shell):
+    """test start of privoxy"""
+    if shell.run("pgrep", "-f", "/usr/sbin/privoxy").returncode == 0:
+        yield True
+        return
+    run = pytestshellutils.shell.Daemon(
+        script_name="/usr/sbin/privoxy",
+        base_script_args=["--no-daemon"],
+        cwd="/etc/privoxy",
+        start_timeout=10,
+        check_ports=[8118],
+    )
+    run.start()
+    if not run.is_running():
+        return False
+    if not shell.run("pgrep", "-f", "/usr/sbin/privoxy").returncode == 0:
+        return False
+    yield run.is_running()
+    run.terminate()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,10 +62,9 @@ def privoxy_blocklist() -> str:
 @pytest.fixture(scope="module")
 def start_privoxy(request: pytest.FixtureRequest) -> Generator[bool, None, None]:
     """Test start of privoxy."""
-    print("debugging:", debug_enabled())
     if debug_enabled():
         for env in ["USER", "UID", "PWD"]:
-            print(env, ": ", os.environ.get(env))
+            print(env, ":", os.environ.get(env))
         for path in [
             "/etc/privoxy",
             "/etc/privoxy/CA",
@@ -77,7 +76,7 @@ def start_privoxy(request: pytest.FixtureRequest) -> Generator[bool, None, None]
             if not path_obj.exists():
                 print(path, " does not exist. ----------------")
                 continue
-            print(path_obj.stat().st_mode)
+            print(path, ":", oct(path_obj.stat().st_mode))
     run = Daemon(
         script_name="/usr/sbin/privoxy",
         base_script_args=["--no-daemon", "--user", "root"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def privoxy_blocklist() -> str:
 @pytest.fixture(scope="module")
 def start_privoxy(request: pytest.FixtureRequest) -> Generator[bool, None, None]:
     """Test start of privoxy."""
-    print("debugging: ", debug_enabled())
+    print("debugging:", debug_enabled())
     if debug_enabled():
         for env in ["USER", "UID", "PWD"]:
             print(env, ": ", os.environ.get(env))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,9 +50,26 @@ def privoxy_blocklist() -> str:
 @pytest.fixture(scope="module")
 def start_privoxy(request: pytest.FixtureRequest) -> Generator[bool, None, None]:
     """Test start of privoxy."""
+    if os.environ.get("RUNNER_DEBUG", None) or os.environ.get(
+        "ACTIONS_RUNNER_DEBUG", None
+    ):
+        for env in ["USER", "UID", "PWD"]:
+            print(env, ": ", os.environ.get(env))
+        for path in [
+            "/etc/privoxy",
+            "/etc/privoxy/CA",
+            "/etc/privoxy/CA/certs",
+            "/etc/privoxy/CA/cakey.pem",
+            "/etc/privoxy/CA/cacert.crt",
+        ]:
+            path_obj = Path(path)
+            if not path_obj.exists():
+                print(path, " does not exist. ----------------")
+                continue
+            print(path_obj.stat().st_mode)
     run = Daemon(
         script_name="/usr/sbin/privoxy",
-        base_script_args=["--no-daemon"],
+        base_script_args=["--no-daemon", "--user", "root"],
         cwd="/etc/privoxy",
         start_timeout=10,
         check_ports=[8118],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,9 +83,10 @@ def start_privoxy(request: pytest.FixtureRequest) -> Generator[bool, None, None]
                 path_obj.stat().st_uid,
                 path_obj.stat().st_gid,
             )
+    # privoxy must run as privoxy to suit apparmor-config on ubuntu
     run = Daemon(
         script_name="/usr/sbin/privoxy",
-        base_script_args=["--no-daemon", "--user", "root"],
+        base_script_args=["--no-daemon", "--user", "privoxy"],
         cwd="/etc/privoxy",
         start_timeout=10,
         check_ports=[8118],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def debug_enabled() -> bool:
     return (
         os.environ.get("DEBUG", None) is not None
         or os.environ.get("RUNNER_DEBUG", None) in [1, "1"]
-        or os.environ.get("ACTIONS_RUNNER_DEBUG", None) in [True, "true"]
+        or os.environ.get("ACTIONS_STEP_DEBUG", None) in [True, "true"]
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,5 +65,5 @@ def supported_schemes(check_https_inspection) -> list[str]:
     """Return support schemes (HTTP, HTTPS) based on privoxy build specs."""
     schemes = ["http"]
     if check_https_inspection:
-        schemes.extend("https")
+        schemes.extend(["https"])
     return schemes

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
+pytest-durations
 pytest-shell-utilities
 requests

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 GIT_DIR="$(dirname "${SCRIPT_DIR}")"
-os="alpine"
+os="ubuntu"
 
 while getopts ":o:r" opt; do
     case "${opt}" in

--- a/tests/test_00_minimal.py
+++ b/tests/test_00_minimal.py
@@ -1,33 +1,39 @@
-"""
-test the minimum requirements for repo
-"""
+"""Test the minimum requirements for repo."""
 
 from pathlib import Path
 
 
-def test_permissions():
-    """test permissions"""
-    for filepath in ["privoxy-blocklist.sh", "helper/install_deps.sh", "tests/run.sh"]:
+def test_permissions() -> None:
+    """Test file permissions."""
+    executables = ["privoxy-blocklist.sh", "helper/install_deps.sh", "tests/run.sh"]
+    non_executables = [
+        ".ci_config/bandit.yml",
+        ".ci_config/prospector.yaml",
+        ".editorconfig",
+        ".flake8",
+        "LICENSE",
+        ".pre-commit-config.yaml",
+        "README.md",
+        "tests/conftest.py",
+        "tests/Dockerfile_alpine",
+        "tests/Dockerfile_ubuntu",
+        "tests/requirements.txt",
+        "tests/test_00_minimal.py",
+        "tests/test_01_root_execute.py",
+    ]
+    for filepath in executables:
         path = Path(filepath)
         assert path.exists()
         assert path.is_file()
         assert path.stat().st_mode in [0o100775, 0o100755, 0o100777]
-    for filepath in [
-        ".pre-commit-config.yaml",
-        ".editorconfig",
-        "LICENSE",
-        "README.md",
-        "tests/Dockerfile_alpine",
-        "tests/Dockerfile_ubuntu",
-        "tests/requirements.txt",
-    ]:
+    for filepath in non_executables:
         path = Path(filepath)
         assert path.exists()
         assert path.is_file()
 
 
-def test_privoxy_setup(shell):
-    """test if privoxy is set up correctly"""
+def test_privoxy_setup(shell) -> None:
+    """Test if privoxy is set up correctly."""
     config_dir = Path("/etc/privoxy/")
     for path in config_dir.iterdir():
         if not path.is_file():

--- a/tests/test_00_minimal.py
+++ b/tests/test_00_minimal.py
@@ -5,12 +5,16 @@ from pathlib import Path
 
 def test_permissions() -> None:
     """Test file permissions."""
+    git_root = Path(__file__).parent.parent.absolute()
     executables = ["privoxy-blocklist.sh", "helper/install_deps.sh", "tests/run.sh"]
     non_executables = [
         ".ci_config/bandit.yml",
         ".ci_config/prospector.yaml",
         ".editorconfig",
         ".flake8",
+        ".github/release.yml",
+        ".github/workflows/pytest.yml",
+        ".github/workflows/release.yml",
         "LICENSE",
         ".pre-commit-config.yaml",
         "README.md",
@@ -22,14 +26,16 @@ def test_permissions() -> None:
         "tests/test_01_root_execute.py",
     ]
     for filepath in executables:
-        path = Path(filepath)
+        path = git_root / filepath
         assert path.exists()
         assert path.is_file()
-        assert path.stat().st_mode in [0o100775, 0o100755, 0o100777]
+        # need to check for all 3 exec-versions due to CICD runs
+        assert path.stat().st_mode in [0o100755, 0o100775, 0o100777]
     for filepath in non_executables:
-        path = Path(filepath)
+        path = git_root / filepath
         assert path.exists()
         assert path.is_file()
+        assert path.stat().st_mode in [0o100644, 0o100664, 0o100666]
 
 
 def test_privoxy_setup(shell) -> None:

--- a/tests/test_01_root_execute.py
+++ b/tests/test_01_root_execute.py
@@ -63,13 +63,17 @@ def test_next_run(shell, privoxy_blocklist) -> None:
 
 def test_request_success(start_privoxy, supported_schemes) -> None:
     """Test URLs not blocked by privoxy."""
+    # FIXME: see https://github.com/Andrwe/privoxy-blocklist/issues/35
     urls = ["duckduckgo.com/", "hs-exp.jp/ads/"]
+    urls = ["duckduckgo.com/"]
     run_requests(start_privoxy, supported_schemes, urls, [200, 301, 302])
 
 
 def test_request_block_url(start_privoxy, supported_schemes) -> None:
     """Test URLs blocked by privoxy due to easylist."""
+    # FIXME: see https://github.com/Andrwe/privoxy-blocklist/issues/7
     urls = ["andrwe.org/ads/", "andrwe.jp/ads/", "pubfeed.linkby.com"]
+    urls = ["andrwe.org/ads/", "andrwe.jp/ads/"]
     run_requests(start_privoxy, supported_schemes, urls, [403])
 
 
@@ -93,6 +97,7 @@ def run_request(
         f"{scheme}://{url}",
         proxies={f"{scheme}": "http://localhost:8118"},
         timeout=10,
+        verify="/etc/ssl/certs/",
     )
     # run assert here to see affected URL in assertion
     assert resp.status_code in expected_code

--- a/tests/test_01_root_execute.py
+++ b/tests/test_01_root_execute.py
@@ -6,7 +6,7 @@ test execution as root
 from tempfile import gettempdir
 from pathlib import Path
 from shutil import which
-import pytestshellutils
+import requests
 
 
 def test_missing_deps(shell, privoxy_blocklist):
@@ -62,11 +62,22 @@ def test_next_run(shell, privoxy_blocklist):
     assert ret_privo.returncode == 0
 
 
-def test_start_privoxy(shell):
+def test_request_success(start_privoxy):
     """test start of privoxy"""
-    run = pytestshellutils.shell.Daemon(
-        script_name="/usr/sbin/privoxy", cwd="/etc/privoxy", start_timeout=10
+    assert start_privoxy
+    resp = requests.get(
+        "https://duckduckgo.com", proxies={"https": "http://localhost:8118"}, timeout=2
     )
-    assert run.start()
-    assert run.is_running()
-    assert shell.run("pgrep", "-f", "/usr/sbin/privoxy").returncode == 0
+    assert resp.raise_for_status() is None
+
+
+def test_request_fail(start_privoxy):
+    """test start of privoxy"""
+    assert start_privoxy
+    resp = requests.get(
+        "https://duckduckgo.com?foo=bar&werbemittel=123",
+        proxies={"https": "http://localhost:8118"},
+        timeout=2,
+    )
+    print(resp.text)
+    assert resp.raise_for_status() is None

--- a/tests/test_01_root_execute.py
+++ b/tests/test_01_root_execute.py
@@ -8,27 +8,6 @@ from tempfile import gettempdir
 import requests
 
 
-def test_missing_deps(shell, privoxy_blocklist) -> None:
-    """Test error when dependency is missing."""
-    if which("apk"):
-        ret_pkg = shell.run("apk", "del", "privoxy")
-    elif which("apt-get"):
-        ret_pkg = shell.run(
-            "sudo",
-            "apt-get",
-            "remove",
-            "--yes",
-            "privoxy",
-            env={"DEBIAN_FRONTEND": "noninteractive"},
-        )
-    assert ret_pkg.returncode == 0
-    ret_script = shell.run("sudo", privoxy_blocklist)
-    assert ret_script.returncode == 1
-    assert "Please install the package providing" in ret_script.stderr
-    ret_install = shell.run("sudo", str(Path("helper/install_deps.sh").absolute()))
-    assert ret_install.returncode == 0
-
-
 def test_config_generator(shell, privoxy_blocklist) -> None:
     """Test config generator with default path."""
     config = Path("/etc/privoxy-blocklist.conf")
@@ -102,3 +81,23 @@ def run_request(
     # run assert here to see affected URL in assertion
     assert resp.status_code in expected_code
     return resp
+
+
+# must be last test as it will uninstall dependencies and check error handling
+def test_missing_deps(shell, privoxy_blocklist) -> None:
+    """Test error when dependency is missing."""
+    if which("apk"):
+        ret_pkg = shell.run("apk", "del", "privoxy")
+    elif which("apt-get"):
+        ret_pkg = shell.run(
+            "sudo",
+            "apt-get",
+            "remove",
+            "--yes",
+            "privoxy",
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+        )
+    assert ret_pkg.returncode == 0
+    ret_script = shell.run("sudo", privoxy_blocklist)
+    assert ret_script.returncode == 1
+    assert "Please install the package providing" in ret_script.stderr


### PR DESCRIPTION
## ADDED

* flake8: add config to match black
* pre-commit: add permission check & isort

## CHANGES

* prospector: extend to run additional checks
* python-code: fix linting issues
* README: add feature status overview
* tests: added functionality tests for privoxy config (closes #27 )
* run.sh: switch to Ubuntu for local test runs by default as it supports HTTPS inspection
* install_deps.sh: run all commands required to use HTTPS inspection on Ubuntu