### PR TITLE
Check privoxy runtime logs

### DIFF
--- a/.ci_config/prospector.yaml
+++ b/.ci_config/prospector.yaml
@@ -13,3 +13,10 @@ bandit:
 
 mypy:
   run: true
+
+pydocstyle:
+  disable:
+    # conflicts with D211
+    - D203
+    # conflicts with D211
+    - D212

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 99

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,12 @@ repos:
     rev: v3.7.0.1
     hooks:
       - id: shfmt
+        args:
+          - "--binary-next-line"
+          - "--case-indent"
+          - "--indent"
+          - "4"
+          - "--space-redirects"
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.12.0.3
     hooks:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The following table shows features of AdBlock Plus filters and there status with
 
 | Feature | Type | Status | Test |
 | ------- | ---- | ------ | ---- |
-| `#$#` | CSS selector - Snippet filter | :question: | :question: |
 | `:-abp-contains()` | extended CSS selector | :question: | :question: |
 | `:-abp-has()` | extended CSS selector | :question: | :question: |
 | `:-abp-properties()` | extended CSS selector | :question: | :question: |
@@ -33,10 +32,22 @@ The following table shows features of AdBlock Plus filters and there status with
 | `\|…\|` | block exact domain matching including scheme | :question: | :question: |
 | `!…` | comments | :white_check_mark: | |
 | `csp=` | filter options | :question: | :question: |
-| `##…[…]` | CSS attribute selector | :question: | :question: |
-| `##` | CSS selector - Element hiding | :white_check_mark: | |
-| `#?#` | CSS selector - Element hiding emulation | :question: | :question: |
-| `#@#` | CSS selector - Element hiding exception | :question: | :question: |
+| `##.class` | global CSS attribute selector with matching for class | :white_check_mark: | :white_check_mark: |
+| `###id` | global CSS attribute selector with matching for id | :white_check_mark: | :white_check_mark: |
+| `##[attribute]` | global CSS attribute selector with matching for attribute-name | :white_check_mark: | :white_check_mark: |
+| `##[attribute=value]` | global CSS attribute selector with matching for attribute-value pair | :white_check_mark: | :white_check_mark: |
+| `##[attribute^=value]` | global CSS attribute selector with matching for attribute with value starting with | :white_check_mark: | :white_check_mark: |
+| `##[attribute$=value]` | global CSS attribute selector with matching for attribute with value ending with | :white_check_mark: | :white_check_mark: |
+| `##[attribute*=value]` | global CSS attribute selector with matching for attribute with value containing | :white_check_mark: | :white_check_mark: |
+| `##html-tag[attribute]` | global CSS attribute selector for html-tag with matching for attribute-name | :construction: | :construction: |
+| `##html-tag[attribute=value]` | global CSS attribute selector for html-tag with matching for attribute-value pair | :construction: | :construction: |
+| `##html-tag[attribute^=value]` | global CSS attribute selector for html-tag with matching for attribute with value starting with | :construction: | :construction: |
+| `##html-tag[attribute$=value]` | global CSS attribute selector for html-tag with matching for attribute with value ending with | :construction: | :construction: |
+| `##html-tag[attribute*=value]` | global CSS attribute selector for html-tag with matching for attribute with value containing | :construction: | :construction: |
+| `[…]#$#` | domain based CSS selector - Snippet filter | :question: | :question: |
+| `[…]##` | domain based CSS selector - Element hiding | :white_check_mark: | |
+| `[…]#?#` | domain based CSS selector - Element hiding emulation | :question: | :question: |
+| `[…]#@#` | domain based CSS selector - Element hiding exception | :question: | :question: |
 | `document` | filter options | :question: | :question: |
 | `~domain=` | filter options | :question: | :question: |
 | `domain=` | filter options | :question: | :question: |

--- a/privoxy-blocklist.sh
+++ b/privoxy-blocklist.sh
@@ -160,6 +160,8 @@ EOF
     if [ -n "${OPT_FILTERS[*]}" ]; then
         FILTERS=("${OPT_FILTERS[@]}")
     fi
+    debug 2 "Content filters: ${OPT_FILTERS[*]:-disabled}"
+
     # load privoxy config
     # shellcheck disable=SC1090
     if [[ -r "${INIT_CONF:-no-init-conf}" ]]; then
@@ -801,7 +803,6 @@ lock
 debug 2 "URL-List: ${URLS[*]}"
 debug 2 "Privoxy-Configdir: ${PRIVOXY_DIR}"
 debug 2 "Temporary directory: ${TMPDIR}"
-debug 2 "Content filters: ${OPT_FILTERS[*]:-disabled}"
 "${method}"
 
 # restore default exit command

--- a/tests/Dockerfile_ubuntu
+++ b/tests/Dockerfile_ubuntu
@@ -5,10 +5,12 @@ COPY		helper/install_deps.sh /install_deps.sh
 ENV		DEBIAN_FRONTEND=noninteractive
 RUN		apt-get update \
 		&& apt-get install --no-install-recommends -q --yes \
+			curl \
 			build-essential \
 			python3-pip \
 			python3-dev \
 			sudo \
+			vim \
 		&& pip install --no-cache-dir -qr /requirements.txt \
 		&& rm -f /requirements.txt \
 		&& install -d -o root -g root /pytest_cache \

--- a/tests/config.py
+++ b/tests/config.py
@@ -7,9 +7,14 @@ content_removed = [
     "MyAdsId3",  # id match
     "AdRight2",  # class match with element having multiple classes
     "data-ad-manager-id",  # attribute match
+    'data-role="tile-ads-module"',  # attribute exact match
+    'onclick="content.ad/"',  # attribute contain match
+    'class="adDisplay-module_foobar"',  # attribute startswith match
+    "onclick=\"location.href='http://www.reimageplus.com/foobar'",  # attribute startswith match
 ]
 content_exists = [
     "ajlkl",  # should exist, although one element is removed by privoxy
+    '"adDisplay-modul"',  # should exist
 ]
 
 # FIXME: see https://github.com/Andrwe/privoxy-blocklist/issues/35

--- a/tests/config.py
+++ b/tests/config.py
@@ -6,6 +6,7 @@ content_removed = [
     "ad_970x250",  # class match: https://www.iphoneitalia.com/
     "MyAdsId3",  # id match
     "AdRight2",  # class match with element having multiple classes
+    "data-ad-manager-id",  # attribute match
 ]
 content_exists = [
     "ajlkl",  # should exist, although one element is removed by privoxy

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,0 +1,69 @@
+"""Configuration of test suite to configure tests."""
+
+from conftest import check_in, check_not_in
+
+content_removed = [
+    "ad_970x250",  # class match: https://www.iphoneitalia.com/
+    "MyAdsId3",  # id match
+    "AdRight2",  # class match with element having multiple classes
+]
+content_exists = [
+    "ajlkl",  # should exist, although one element is removed by privoxy
+]
+
+# FIXME: see https://github.com/Andrwe/privoxy-blocklist/issues/35
+urls_allowed = ["duckduckgo.com/", "hs-exp.jp/ads/"]
+urls_allowed = ["duckduckgo.com/"]
+
+# FIXME: implement regex-filter for domains, e.g.
+#   /^https?:\/\/s3\.*.*\.amazonaws\.com\/[a-f0-9]{45,}\/[a-f,0-9]{8,10}$/$script,
+#       third-party,xmlhttprequest,domain=~amazon.com
+urls_blocked = [
+    "andrwe.org/ads/",
+    "andrwe.jp/ads/",
+    "pubfeed.linkby.com",
+    f"s3.{'a'*6}.amazonaws.com/{'0123abcd'*6}/{'ab,12'*2}/",
+]
+urls_blocked = ["andrwe.org/ads/", "andrwe.jp/ads/", "pubfeed.linkby.com"]
+
+config_checks = {
+    "url_extended_config.conf": [
+        (
+            check_in,
+            "Processing https://raw.githubusercontent.com/easylist/easylist/master/"
+            "easylist/easylist_allowlist_general_hide.txt",
+        ),
+        (
+            check_in,
+            "Processing https://easylist-downloads.adblockplus.org/easylistgermany.txt",
+        ),
+        (
+            check_in,
+            "The list recieved from https://raw.githubusercontent.com/easylist/easylist/master"
+            "/easylist/easylist_allowlist_general_hide.txt does not contain AdblockPlus list "
+            "header. Try to process anyway.",
+        ),
+        (
+            check_not_in,
+            "created and added image handler",
+        ),
+    ],
+    "debugging.conf": [
+        (
+            check_in,
+            "Processing https://easylist-downloads.adblockplus.org/easylistgermany.txt",
+        ),
+        (
+            check_not_in,
+            "does not contain AdblockPlus list header.",
+        ),
+        (
+            check_in,
+            "‘/tmp/privoxy-blocklist.sh/easylist.txt’ saved",
+        ),
+        (
+            check_in,
+            "created and added image handler",
+        ),
+    ],
+}

--- a/tests/configs/debugging.conf
+++ b/tests/configs/debugging.conf
@@ -7,6 +7,11 @@ URLS=(
   "https://easylist-downloads.adblockplus.org/easylist.txt"
 )
 
+# array of content filters to convert
+#   for supported values check: $0 -h
+#   empty by default to deactivate as content filters slowdown privoxy a lot
+FILTERS=()
+
 # config for privoxy initscript providing PRIVOXY_CONF, PRIVOXY_USER and PRIVOXY_GROUP
 #INIT_CONF="/etc/conf.d/privoxy"
 

--- a/tests/configs/url_extended_config.conf
+++ b/tests/configs/url_extended_config.conf
@@ -8,6 +8,11 @@ URLS=(
   "https://raw.githubusercontent.com/easylist/easylist/master/easylist/easylist_allowlist_general_hide.txt"
 )
 
+# array of content filters to convert
+#   for supported values check: $0 -h
+#   empty by default to deactivate as content filters slowdown privoxy a lot
+FILTERS=()
+
 # config for privoxy initscript providing PRIVOXY_CONF, PRIVOXY_USER and PRIVOXY_GROUP
 #INIT_CONF="/etc/conf.d/privoxy"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,26 @@ def webserver(httpserver) -> UrlParsed:
 
 
 @pytest.fixture(scope="module")
+def filtertypes() -> list[str]:
+    """Return filtertypes supported by privoxy-blocklist."""
+    filter_types = []
+    with Path(__file__).parent.parent.joinpath("privoxy-blocklist.sh").open(
+        "r", encoding="UTF-8"
+    ) as f_h:
+        found_line = False
+        for line in f_h.readlines():
+            if not found_line and not line.startswith("FILTERTYPES"):
+                continue
+            if line.startswith("FILTERTYPES"):
+                found_line = True
+                continue
+            if line.endswith(")\n"):
+                break
+            filter_types.append(line.strip().strip('"'))
+    return filter_types
+
+
+@pytest.fixture(scope="module")
 def privoxy_blocklist() -> str:
     """Return the path to privoxy-blocklist.sh."""
     for known_path in [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,16 @@ def debug_enabled() -> bool:
     )
 
 
+def check_in(needle: str, haystack: str) -> bool:
+    """Check given haystack for given string."""
+    return needle in haystack
+
+
+def check_not_in(needle: str, haystack: str) -> bool:
+    """Check that given string is not in given text."""
+    return needle not in haystack
+
+
 # based on
 # https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
 @pytest.hookimpl(wrapper=True, tryfirst=True)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-durations
+pytest-httpserver
 pytest-shell-utilities
 requests

--- a/tests/response.html
+++ b/tests/response.html
@@ -1,0 +1,9 @@
+<html>
+	<body>
+		<div>just-some-test-string-always-present</div>
+		<div class="ad_970x250">single class should be removed</div>
+		<div class="asd ajlkl AdRight2">multiple classes that should be removed</div>
+		<div class="asd ajlkl"> multiple classes that should exist </div>
+		<div id="MyAdsId3">id should be removed</div>
+	</body>
+</html>

--- a/tests/response.html
+++ b/tests/response.html
@@ -5,5 +5,6 @@
 		<div class="asd ajlkl AdRight2">multiple classes that should be removed</div>
 		<div class="asd ajlkl"> multiple classes that should exist </div>
 		<div id="MyAdsId3">id should be removed</div>
+		<div data-ad-manager-id class="success-valid-class">name-only attibute should be removed</div>
 	</body>
 </html>

--- a/tests/response.html
+++ b/tests/response.html
@@ -6,5 +6,11 @@
 		<div class="asd ajlkl"> multiple classes that should exist </div>
 		<div id="MyAdsId3">id should be removed</div>
 		<div data-ad-manager-id class="success-valid-class">name-only attibute should be removed</div>
+		<div data-role="tile-ads-module" class="success-valid-class">exact match attibute should be removed</div>
+		<div onclick="foo_content.ad/-asd">1. contain match attribute should be removed</div>
+		<div onclick="content.ad/">2. contain match attribute should be removed</div>
+		<div class="adDisplay-module_foobar">1. startswith match attribute should be removed</div>
+		<div class="adDisplay-modul">startswith match attribute should be exist</div>
+		<div onclick="location.href='http://www.reimageplus.com/foobar'">2. startswith match attribute should be removed</div>
 	</body>
 </html>

--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -1,0 +1,5 @@
+[pycodestyle]
+max-line-length = 99
+
+[flake8]
+max-line-length = 99

--- a/tests/test_00_minimal.py
+++ b/tests/test_00_minimal.py
@@ -11,7 +11,6 @@ def test_permissions() -> None:
         ".ci_config/bandit.yml",
         ".ci_config/prospector.yaml",
         ".editorconfig",
-        ".flake8",
         ".github/release.yml",
         ".github/workflows/pytest.yml",
         ".github/workflows/release.yml",
@@ -22,6 +21,7 @@ def test_permissions() -> None:
         "tests/Dockerfile_alpine",
         "tests/Dockerfile_ubuntu",
         "tests/requirements.txt",
+        "tests/setup.cfg",
         "tests/test_00_minimal.py",
         "tests/test_01_root_execute.py",
     ]

--- a/tests/test_01_root_execute.py
+++ b/tests/test_01_root_execute.py
@@ -150,6 +150,10 @@ def test_missing_deps(shell, privoxy_blocklist) -> None:
     assert "Please install the package providing" in ret_script.stderr
 
 
+def test_privoxy_runtime_log() -> None:
+    """NOOP function to support checking privoxy logs during tear-down."""
+
+
 # Heloer functions
 
 

--- a/tests/test_01_root_execute.py
+++ b/tests/test_01_root_execute.py
@@ -48,9 +48,21 @@ def test_version_option(shell, tmp_path, privoxy_blocklist) -> None:
     assert ret.stdout == "Version: 0.0.1\n"
 
 
-def test_next_run(shell, privoxy_blocklist) -> None:
+def test_filter_check(shell, privoxy_blocklist) -> None:
+    """Test filtertype check."""
+    cmd = [privoxy_blocklist, "-f", "bla"]
+    ret_script = shell.run(*cmd)
+    assert ret_script.returncode == 1
+    assert "" == ret_script.stdout
+    assert "Unknown filters: bla" in ret_script.stderr.strip()
+
+
+def test_next_run(shell, privoxy_blocklist, filtertypes) -> None:
     """Test followup runs."""
-    ret_script = shell.run(privoxy_blocklist)
+    cmd = [privoxy_blocklist]
+    for filtertype in filtertypes:
+        cmd.extend(["-f", filtertype])
+    ret_script = shell.run(*cmd)
     assert ret_script.returncode == 0
     ret_privo = shell.run(
         "/usr/sbin/privoxy", "--no-daemon", "--config-test", "/etc/privoxy/config"


### PR DESCRIPTION
# BREAKING CHANGE

Because content filtering with Privoxy can slowdown loading websites a lot it is disabled now by default.
To enable it add the following line to your configuration which will activate all supported content filters again:

```bash
FILTERS=(
    attribute_global_name
    attribute_global_exact
    attribute_global_contain
    attribute_global_startswith
    attribute_global_endswith
    class_global
    id_global
)
```

During testing of these filters I got a slowdown of page loading up to 4 minutes.
This mostly depends on the amount of HTML-elements and general size of page.
The current implementation already tweaks the filters as much as possible.
Maybe additional tweaking can be done in the Privoxy configuration.

## ADDED

* privoxy-blocklist: configuration & cli-flag to activate and control content-filter conversion
* test-suite: add configuration file to centralize test configurations
* test-suite: add http-server to test content filters without external dependencies
* test-suite: add tests for content filters
* test-suite: add tests for runtime errors (close #46 )

## CHANGES

* privoxy-blocklist: change order of arguments of debug() to simplify writing messages
* privoxy-blocklist: apply shfmt fixes
* test-suite: add vim & curl to docker image to simplify debugging
* test-suite: move check_in() and check_not_in() to conftest.py to allow re-usage in different scripts
* 

## FIXED

* privoxy-blocklist: support for HTML element filter conversion (global filters only) (relates to #8 )
* privoxy-blocklist: fix several runtime errors caused by conversion routine